### PR TITLE
Adding lifecycle for view will show / hide.

### DIFF
--- a/app/src/main/java/com/ustwo/boilerplate/base/BaseActivity.java
+++ b/app/src/main/java/com/ustwo/boilerplate/base/BaseActivity.java
@@ -21,6 +21,18 @@ public abstract class BaseActivity<V extends BaseView, C extends BaseComponent>
   }
 
   @Override
+  protected void onResume() {
+    getPresenter().onViewWillShow(getPresenterView());
+    super.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    getPresenter().onViewWillHide();
+    super.onPause();
+  }
+
+  @Override
   protected void onDestroy() {
     getPresenter().onViewDetached();
     super.onDestroy();

--- a/app/src/main/java/com/ustwo/boilerplate/base/BasePresenter.java
+++ b/app/src/main/java/com/ustwo/boilerplate/base/BasePresenter.java
@@ -30,7 +30,6 @@ public class BasePresenter<T extends BaseView> {
 
   /**
    * On view will show. Called when your view is about to be seen on the screen.
-   * @param view
    */
   @CallSuper
   public void onViewWillShow(@NonNull final T view) {

--- a/app/src/main/java/com/ustwo/boilerplate/base/BasePresenter.java
+++ b/app/src/main/java/com/ustwo/boilerplate/base/BasePresenter.java
@@ -6,7 +6,8 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
 public class BasePresenter<T extends BaseView> {
-  private final CompositeDisposable disposables = new CompositeDisposable();
+  private final CompositeDisposable attachedDisposables = new CompositeDisposable();
+  private final CompositeDisposable visibleDisposables = new CompositeDisposable();
   private T view;
 
   protected BasePresenter() {
@@ -28,6 +29,23 @@ public class BasePresenter<T extends BaseView> {
   }
 
   /**
+   * On view will show. Called when your view is about to be seen on the screen.
+   * @param view
+   */
+  @CallSuper
+  public void onViewWillShow(@NonNull final T view) {
+
+  }
+
+  /**
+   * On view will hide. Called when your view is about to hide from the screen.
+   */
+  @CallSuper
+  public void onViewWillHide() {
+    visibleDisposables.clear();
+  }
+
+  /**
    * On view detached. Intended as a cleanup process that should be called when the view will no
    * longer be in use.
    */
@@ -38,17 +56,17 @@ public class BasePresenter<T extends BaseView> {
     }
     view = null;
 
-    disposables.clear();
+    attachedDisposables.clear();
   }
 
   /**
-   * Dispose on view detach.
+   * Dispose on view will hide.
    *
-   * @param disposable Disposable to be disposed of upon view detachment
+   * @param disposable Disposable to be disposed of upon view will hide
    */
   @CallSuper
-  protected void disposeOnViewDetach(@NonNull final Disposable disposable) {
-    disposables.add(disposable);
+  protected void disposeOnViewWillHide(@NonNull final Disposable disposable) {
+    visibleDisposables.add(disposable);
   }
 
   public boolean isViewAttached() {


### PR DESCRIPTION
We're adding lifecycle events for a view showing / hiding to make it easier to perform logic based on visibility. This can be useful for operations you only want to run when the view is shown.
e.g. start / stop accelerometer.

We've not added any state checks in the `BasePresenter` at present since it may add a lot of complexity without much value. What do you think?