### PR TITLE
Making ExampleInstrumentedTest more robust

### DIFF
--- a/app/src/androidTest/java/com/ustwo/boilerplate/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/ustwo/boilerplate/ExampleInstrumentedTest.java
@@ -5,6 +5,7 @@ import static junit.framework.Assert.assertEquals;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.content.ContextCompat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -20,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         final Context appContext = InstrumentationRegistry.getTargetContext();
 
-        assertEquals("com.ustwo.boilerplate.debug", appContext.getPackageName());
+        assertEquals(0xffffffff, ContextCompat.getColor(appContext, android.R.color.white));
     }
 }


### PR DESCRIPTION
Fixes #48 

Replacing string check with a colour resource check. Re-factoring the package won't affect this test which makes creating a project from the boilerplate a step simpler.