### PR TITLE
Adding a dependency version checker and dependency spring clean

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,9 +65,6 @@ dependencies {
     compile library.dagger
     annotationProcessor library.daggerCompiler
 
-    provided library.autoValue
-    annotationProcessor library.autoValue
-
     debugCompile library.leakCanary
     releaseCompile library.leakCanaryNoOp
     testCompile library.leakCanaryNoOp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'spoon'
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'findbugs'
 apply plugin: 'hu.supercluster.paperwork'
+apply plugin: 'com.github.ben-manes.versions'
 
 apply from: '../config/findbugs.gradle'
 apply from: '../config/pmd.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
         classpath plugin.dexCount
         classpath plugin.jacoco
         classpath plugin.paperwork
+        classpath plugin.gradleVersions
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/circle.yml
+++ b/circle.yml
@@ -10,14 +10,13 @@ dependencies:
     - openssl aes-256-cbc -d -in release.keystore.cipher -out release.keystore -k $CI_SECRETS_KEY
     - if [ ! -e $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS ]; then echo y | android update sdk --no-ui --all --filter build-tools-$ANDROID_BUILD_TOOLS; fi
     - if [ ! -e $ANDROID_HOME/platforms/android-$ANDROID_PLATFORM ]; then echo y | android update sdk --no-ui --all --filter "android-${ANDROID_PLATFORM}"; fi
-    - if [ ! -e $ANDROID_HOME/extras/android/m2repository ]; then echo y | android update sdk -u -a -t extra-android-m2repository; fi
-    - if [ ! -e $ANDROID_HOME/extras/google/m2repository ]; then echo y | android update sdk -u -a -t extra-google-m2repository; fi
+    - echo y | android update sdk -u -a -t extra-android-m2repository
+    - echo y | android update sdk -u -a -t extra-google-m2repository
 
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.1
     - /usr/local/android-sdk-linux/platforms/android-24
     - /usr/local/android-sdk-linux/tools
-    - /usr/local/android-sdk-linux/extras
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ dependencies:
     - openssl aes-256-cbc -d -in release.keystore.cipher -out release.keystore -k $CI_SECRETS_KEY
     - if [ ! -e $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS ]; then echo y | android update sdk --no-ui --all --filter build-tools-$ANDROID_BUILD_TOOLS; fi
     - if [ ! -e $ANDROID_HOME/platforms/android-$ANDROID_PLATFORM ]; then echo y | android update sdk --no-ui --all --filter "android-${ANDROID_PLATFORM}"; fi
+    - echo y | android update sdk -u -a -t extra-google-m2repository
+    - echo y | android update sdk -u -a -t extra-android-m2repository
+
 
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.1

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ dependencies:
     - openssl aes-256-cbc -d -in release.keystore.cipher -out release.keystore -k $CI_SECRETS_KEY
     - if [ ! -e $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS ]; then echo y | android update sdk --no-ui --all --filter build-tools-$ANDROID_BUILD_TOOLS; fi
     - if [ ! -e $ANDROID_HOME/platforms/android-$ANDROID_PLATFORM ]; then echo y | android update sdk --no-ui --all --filter "android-${ANDROID_PLATFORM}"; fi
-    - if [ ! -e $ANDROID_HOME/extras/android/m2repository ]; then echo y | android update sdk -u -a -t extra-android-m2repository"; fi
-    - if [ ! -e $ANDROID_HOME/extras/google/m2repository ]; then echo y | android update sdk -u -a -t extra-google-m2repository"; fi
+    - if [ ! -e $ANDROID_HOME/extras/android/m2repository ]; then echo y | android update sdk -u -a -t extra-android-m2repository; fi
+    - if [ ! -e $ANDROID_HOME/extras/google/m2repository ]; then echo y | android update sdk -u -a -t extra-google-m2repository; fi
 
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.1

--- a/circle.yml
+++ b/circle.yml
@@ -10,14 +10,14 @@ dependencies:
     - openssl aes-256-cbc -d -in release.keystore.cipher -out release.keystore -k $CI_SECRETS_KEY
     - if [ ! -e $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS ]; then echo y | android update sdk --no-ui --all --filter build-tools-$ANDROID_BUILD_TOOLS; fi
     - if [ ! -e $ANDROID_HOME/platforms/android-$ANDROID_PLATFORM ]; then echo y | android update sdk --no-ui --all --filter "android-${ANDROID_PLATFORM}"; fi
-    - echo y | android update sdk -u -a -t extra-google-m2repository
-    - echo y | android update sdk -u -a -t extra-android-m2repository
-
+    - if [ ! -e $ANDROID_HOME/extras/android/m2repository ]; then echo y | android update sdk -u -a -t extra-android-m2repository"; fi
+    - if [ ! -e $ANDROID_HOME/extras/google/m2repository ]; then echo y | android update sdk -u -a -t extra-google-m2repository"; fi
 
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.1
     - /usr/local/android-sdk-linux/platforms/android-24
     - /usr/local/android-sdk-linux/tools
+    - /usr/local/android-sdk-linux/extras
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 machine:
   environment:
     ANDROID_HOME: /usr/local/android-sdk-linux
-    ANDROID_BUILD_TOOLS: 24.0.1
-    ANDROID_PLATFORM: 24
+    ANDROID_BUILD_TOOLS: 25.0.2
+    ANDROID_PLATFORM: 25
 
 dependencies:
   pre:

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -11,17 +11,17 @@ ext.versions = [
         rxJava: '2.0.1',
         rxAndroid: '2.0.1',
         rxLint: '1.2',
-        timber: "4.5.1",
-        butterknife: "8.5.1",
-        paperwork: "1.2.7",
+        timber: '4.5.1',
+        butterknife: '8.5.1',
+        paperwork: '1.2.7',
 
         // Testing / debug
         jUnit: '4.12',
         espresso: '2.2.2',
         spoon: '1.7.1',
         leakCanary: '1.5',
-        stetho: "1.4.2",
-        mockito: "2.2.22",
+        stetho: '1.4.2',
+        mockito: '2.2.22',
 
         // Gradle plugins
         androidGradlePlugin: '2.2.3',

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -4,23 +4,23 @@ ext.versions = [
         androidTargetSdk: 24,
         androidCompileSdk: 24,
         androidBuildTools: '24.0.1',
-        androidSupportLibrary: '24.2.0',
+        androidSupportLibrary: '25.2.0',
 
         // App dependencies
         dagger: '2.7',
         rxJava: '2.0.1',
         rxAndroid: '2.0.1',
-        rxLint: '1.0',
-        timber: "4.3.1",
-        butterknife: "8.4.0",
+        rxLint: '1.2',
+        timber: "4.5.1",
+        butterknife: "8.5.1",
         paperwork: "1.2.7",
 
         // Testing / debug
         jUnit: '4.12',
         espresso: '2.2.2',
-        spoon: '1.7.0',
+        spoon: '1.7.1',
         leakCanary: '1.5',
-        stetho: "1.4.1",
+        stetho: "1.4.2",
         mockito: "2.2.22",
 
         // Gradle plugins

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -29,7 +29,8 @@ ext.versions = [
         dexCountGradlePlugin: '0.6.1',
         spoonGradlePlugin: '1.2.2',
         errorProneGradlePlugin: '0.0.8',
-        jacocoGradlePlugin: '0.7.7.201606060606'
+        jacocoGradlePlugin: '0.7.7.201606060606',
+        gradleVersions: '0.14.0'
 ]
 
 ext.library = [
@@ -65,5 +66,6 @@ ext.plugin = [
         errorProne: "net.ltgt.gradle:gradle-errorprone-plugin:$versions.errorProneGradlePlugin",
         dexCount: "com.getkeepsafe.dexcount:dexcount-gradle-plugin:$versions.dexCountGradlePlugin",
         jacoco: "org.jacoco:org.jacoco.core:$versions.jacocoGradlePlugin",
-        paperwork: "hu.supercluster:paperwork-plugin:$versions.paperwork"
+        paperwork: "hu.supercluster:paperwork-plugin:$versions.paperwork",
+        gradleVersions: "com.github.ben-manes:gradle-versions-plugin:$versions.gradleVersions"
 ]

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -11,13 +11,8 @@ ext.versions = [
         rxJava: '2.0.1',
         rxAndroid: '2.0.1',
         rxLint: '1.0',
-        autoValue: '1.2',
         timber: "4.3.1",
         butterknife: "8.4.0",
-        threeTenAndroid: "1.0.4",
-        retrofit: "2.1.0",
-        retrofitRxJavaAdapter: "1.0.0",
-        calligraphy: "2.2.0",
         paperwork: "1.2.7",
 
         // Testing / debug
@@ -40,8 +35,6 @@ ext.versions = [
 ext.library = [
         // Android dependencies
         androidSupportAppCompat: "com.android.support:appcompat-v7:$versions.androidSupportLibrary",
-        androidSupportDesign: "com.android.support:design:$versions.androidSupportLibrary",
-        androidSupportRecyclerView: "com.android.support:recyclerview-v7:$versions.androidSupportLibrary",
 
         // App dependencies
         dagger: "com.google.dagger:dagger:$versions.dagger",
@@ -49,15 +42,9 @@ ext.library = [
         rxJava: "io.reactivex.rxjava2:rxjava:$versions.rxJava",
         rxAndroid: "io.reactivex.rxjava2:rxandroid:$versions.rxAndroid",
         rxLint: "nl.littlerobots.rxlint:rxlint:$versions.rxLint",
-        autoValue: "com.google.auto.value:auto-value:$versions.autoValue",
         timber: "com.jakewharton.timber:timber:$versions.timber",
         butterknife: "com.jakewharton:butterknife:$versions.butterknife",
         butterknifeCompiler: "com.jakewharton:butterknife-compiler:$versions.butterknife",
-        threeTenAndroid: "com.jakewharton.threetenabp:threetenabp:$versions.threeTenAndroid",
-        retrofit: "com.squareup.retrofit2:retrofit:$versions.retrofit",
-        retrofitGsonConverter: "com.squareup.retrofit2:converter-gson:$versions.retrofit",
-        retrofitRxJavaAdapter: "com.jakewharton.retrofit:retrofit2-rxjava2-adapter:$versions.retrofitRxJavaAdapter",
-        calligraphy: "uk.co.chrisjenx:calligraphy:$versions.calligraphy",
         paperwork: "hu.supercluster:paperwork:$versions.paperwork",
 
         // Testing / debug

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -1,9 +1,9 @@
 ext.versions = [
         // Android libs
         androidMinSdk: 19,
-        androidTargetSdk: 24,
-        androidCompileSdk: 24,
-        androidBuildTools: '24.0.1',
+        androidTargetSdk: 25,
+        androidCompileSdk: 25,
+        androidBuildTools: '25.0.2',
         androidSupportLibrary: '25.2.0',
 
         // App dependencies


### PR DESCRIPTION
Fixes #36 

- Adding a gradle plugin to check whether dependencies are out of date
- Removing dependencies that aren't used in the boilerplate. Useful dependencies can be added to a gist for easy inclusion.
- Upgrading out of date dependency versions
- Fixing CI to support updating support library versions