### PR TITLE
Ignored Mac specific OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ fabric.properties
 # modules.xml
 # .idea/misc.xml 
 # *.ipr
+
+# OS files
+.DS_Store


### PR DESCRIPTION
Fixes #64 

Updating `.gitignore` to ignore `.DS_Store`